### PR TITLE
Add option to disable cycling

### DIFF
--- a/addon/mixins/models-navigation.js
+++ b/addon/mixins/models-navigation.js
@@ -39,11 +39,15 @@ export default Ember.Mixin.create({
 
   actions: {
     previous: function() {
-      this.navigate(-1);
+      if (!this.get('disablePrevious')) {
+        this.navigate(-1);
+      }
     },
 
     next: function() {
-      this.navigate(1);
+      if (!this.get('disableNext')) {
+        this.navigate(-1);
+      }
     }
   }
 });

--- a/addon/mixins/models-navigation.js
+++ b/addon/mixins/models-navigation.js
@@ -5,6 +5,7 @@ export default Ember.Mixin.create({
   navigableModels: null,
   navigableModel: Ember.computed.alias('model'),
   modelRouteParams: [],
+  disableCycling: false,
 
   initializeIndex: function() {
     if (this.get('index') == null) {
@@ -25,6 +26,16 @@ export default Ember.Mixin.create({
     this.set('index', newModelIndex);
     this.transitionToRoute(...this.get('modelRouteParams').concat(newModel.get('id')));
   },
+
+  lastModel: Ember.computed('index', function() {
+    return this.get('index') === this.get('navigableModels.length') - 1;
+  }),
+
+  firstModel: Ember.computed.equal('index', 0),
+
+  disableNext: Ember.computed.and('lastModel', 'disableCycling'),
+
+  disablePrevious: Ember.computed.and('firstModel', 'disableCycling'),
 
   actions: {
     previous: function() {

--- a/addon/mixins/models-navigation.js
+++ b/addon/mixins/models-navigation.js
@@ -6,6 +6,12 @@ export default Ember.Mixin.create({
   navigableModel: Ember.computed.alias('model'),
   modelRouteParams: [],
   disableCycling: false,
+  lastModel: Ember.computed('index', function() {
+    return this.get('index') === this.get('navigableModels.length') - 1;
+  }),
+  firstModel: Ember.computed.equal('index', 0),
+  disableNext: Ember.computed.and('lastModel', 'disableCycling'),
+  disablePrevious: Ember.computed.and('firstModel', 'disableCycling'),
 
   initializeIndex: function() {
     if (this.get('index') == null) {
@@ -26,16 +32,6 @@ export default Ember.Mixin.create({
     this.set('index', newModelIndex);
     this.transitionToRoute(...this.get('modelRouteParams').concat(newModel.get('id')));
   },
-
-  lastModel: Ember.computed('index', function() {
-    return this.get('index') === this.get('navigableModels.length') - 1;
-  }),
-
-  firstModel: Ember.computed.equal('index', 0),
-
-  disableNext: Ember.computed.and('lastModel', 'disableCycling'),
-
-  disablePrevious: Ember.computed.and('firstModel', 'disableCycling'),
 
   actions: {
     previous: function() {

--- a/addon/mixins/models-navigation.js
+++ b/addon/mixins/models-navigation.js
@@ -3,15 +3,16 @@ import Ember from 'ember';
 export default Ember.Mixin.create({
   index: null,
   navigableModels: null,
-  navigableModel: Ember.computed.alias('model'),
   modelRouteParams: [],
   disableCycling: false,
-  lastModel: Ember.computed('index', function() {
-    return this.get('index') === this.get('navigableModels.length') - 1;
-  }),
+  navigableModel: Ember.computed.alias('model'),
   firstModel: Ember.computed.equal('index', 0),
   disableNext: Ember.computed.and('lastModel', 'disableCycling'),
   disablePrevious: Ember.computed.and('firstModel', 'disableCycling'),
+
+  lastModel: Ember.computed('index', function() {
+    return this.get('index') === this.get('navigableModels.length') - 1;
+  }),
 
   initializeIndex: function() {
     if (this.get('index') == null) {

--- a/app/templates/components/as-side-panel.hbs
+++ b/app/templates/components/as-side-panel.hbs
@@ -3,7 +3,7 @@
     <div class="content">
       <ul class="navigation-actions">
         <li><button disabled={{disablePrevious}} class="previous" {{action "previous"}}></button></li>
-        <li><button disabled={{disablePrevious}} class="next" {{action "next"}}></button></li>
+        <li><button disabled={{disableNext}} class="next" {{action "next"}}></button></li>
       </ul>
     </div>
 

--- a/app/templates/components/as-side-panel.hbs
+++ b/app/templates/components/as-side-panel.hbs
@@ -2,8 +2,8 @@
   <div class="actions">
     <div class="content">
       <ul class="navigation-actions">
-        <li><button class="previous" {{action "previous"}}></button></li>
-        <li><button class="next" {{action "next"}}></button></li>
+        <li><button disabled={{disablePrevious}} class="previous" {{action "previous"}}></button></li>
+        <li><button disabled={{disablePrevious}} class="next" {{action "next"}}></button></li>
       </ul>
     </div>
 


### PR DESCRIPTION
# What's up

In some collections we do not want to cycle to the first element after reaching the end. This would disable the buttons (and actions) when the option is switched on and the end (beginning) of the collection is reached.