### PR TITLE
Replace the sidebar width property animation for the collapsed state

### DIFF
--- a/addon/components/as-sidebar.js
+++ b/addon/components/as-sidebar.js
@@ -12,7 +12,7 @@ export default Ember.Component.extend({
     var cssDuration = this.$().css('transition-duration');
     var duration = parseFloat(cssDuration);
 
-    if (cssDuration.indexOf('ms') != -1) {
+    if (cssDuration.indexOf('ms') !== -1) {
       return duration;
     } else {
       return duration * 1000;

--- a/addon/components/as-sidebar.js
+++ b/addon/components/as-sidebar.js
@@ -20,10 +20,10 @@ export default Ember.Component.extend({
   },
 
   didInsertElement: function() {
-    this.addObserver('isCollapsed', this, this.resetScrollableElements);
+    this.addObserver('isCollapsed', this, this.updateScrollableElements);
   },
 
-  resetScrollableElements: function() {
+  updateScrollableElements: function() {
     var duration = this.$().css('transition-duration');
     duration = (duration.indexOf("ms")>-1) ? parseFloat(duration) : parseFloat(duration) * 1000;
 

--- a/addon/components/as-sidebar.js
+++ b/addon/components/as-sidebar.js
@@ -8,6 +8,17 @@ export default Ember.Component.extend({
   navigationItems: [],
   isCollapsed: false,
 
+  transitionDuration: Ember.computed(function() {
+    var cssDuration = this.$().css('transition-duration');
+    var duration = parseFloat(cssDuration);
+
+    if (cssDuration.indexOf('ms') != -1) {
+      return duration;
+    } else {
+      return duration * 1000;
+    }
+  }).volatile(),
+
   actions: {
     toggleCollapse: function() {
       this.toggleProperty('isCollapsed');
@@ -24,13 +35,12 @@ export default Ember.Component.extend({
   },
 
   updateScrollableElements: function() {
-    var duration = this.$().css('transition-duration');
-    duration = (duration.indexOf("ms")>-1) ? parseFloat(duration) : parseFloat(duration) * 1000;
-
     var interval = window.setInterval(function() {
       Ember.$('.scrollable').TrackpadScrollEmulator('recalculate');
     }, 10);
 
-    Ember.run.later(function() { window.clearInterval(interval); }, duration);
+    Ember.run.later(function() {
+      window.clearInterval(interval);
+    }, this.get('transitionDuration'));
   }
 });

--- a/addon/components/as-sidebar.js
+++ b/addon/components/as-sidebar.js
@@ -24,13 +24,13 @@ export default Ember.Component.extend({
   },
 
   resetScrollableElements: function() {
-    this.$().velocity({
-      opacity: 1
-    }, {
-      duration: 325,
-      progress: function() {
-        Ember.$('.scrollable').TrackpadScrollEmulator('recalculate');
-      }
-    });
+    var duration = this.$().css('transition-duration');
+    duration = (duration.indexOf("ms")>-1) ? parseFloat(duration) : parseFloat(duration) * 1000;
+
+    var interval = window.setInterval(function() {
+      Ember.$('.scrollable').TrackpadScrollEmulator('recalculate')
+    }, 10);
+
+    Ember.run.later(function() { window.clearInterval(interval); }, duration);
   }
 });

--- a/addon/components/as-sidebar.js
+++ b/addon/components/as-sidebar.js
@@ -28,7 +28,7 @@ export default Ember.Component.extend({
     duration = (duration.indexOf("ms")>-1) ? parseFloat(duration) : parseFloat(duration) * 1000;
 
     var interval = window.setInterval(function() {
-      Ember.$('.scrollable').TrackpadScrollEmulator('recalculate')
+      Ember.$('.scrollable').TrackpadScrollEmulator('recalculate');
     }, 10);
 
     Ember.run.later(function() { window.clearInterval(interval); }, duration);

--- a/addon/components/as-sidebar.js
+++ b/addon/components/as-sidebar.js
@@ -20,22 +20,14 @@ export default Ember.Component.extend({
   },
 
   didInsertElement: function() {
-    this.addObserver('isCollapsed', this, this.animateWidth);
+    this.addObserver('isCollapsed', this, this.resetScrollableElements);
   },
 
-  animateWidth: function() {
-    var growth;
-
-    if (this.get('isCollapsed')) {
-      growth = '-= 170px';
-    } else {
-      growth = '+= 170px';
-    }
-
+  resetScrollableElements: function() {
     this.$().velocity({
-      width: growth
+      opacity: 1
     }, {
-      duration: 150,
+      duration: 325,
       progress: function() {
         Ember.$('.scrollable').TrackpadScrollEmulator('recalculate');
       }

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "ember-qunit": "0.3.0",
     "ember-qunit-notifications": "0.0.7",
     "qunit": "1.17.1",
-    "paint": "0.7.21",
+    "paint": "0.7.22",
     "spinjs": "2.0.1"
   },
   "resolutions": {


### PR DESCRIPTION
**Issue**
Each time we make a change to the sidebar width, we have to follow with the as-sidebar component.
The fact that we need to recalculate the scrollable wrappers each time the collapsing is triggered adds another layer of complexity.

**Fix**
Let paint handle the sidebar animation _(css only, https://github.com/alphasights/paint/pull/60)_

The animation duration property is less likely to be removed, so this would give us free hands to control the sidebar animation / size from CSS at all times.

**Before**
http://cl.ly/0V0P1Z1L313C

**After**
http://cl.ly/2n2w092B0K0S