### PR TITLE
Fix depedencies

### DIFF
--- a/blueprints/ember-cli-paint/files/app/styles/app.scss
+++ b/blueprints/ember-cli-paint/files/app/styles/app.scss
@@ -1,2 +1,0 @@
-@import 'paint-settings';
-@import 'bower_components/paint/paint';

--- a/blueprints/ember-cli-paint/files/app/templates/application.hbs
+++ b/blueprints/ember-cli-paint/files/app/templates/application.hbs
@@ -1,5 +1,0 @@
-<main>
-  {{#as-scrollable class="content"}}
-    {{outlet}}
-  {{/as-scrollable}}
-</main>

--- a/blueprints/ember-cli-paint/files/app/views/application.js
+++ b/blueprints/ember-cli-paint/files/app/views/application.js
@@ -1,5 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.View.extend({
-  classNameBindings: [':application']
-});

--- a/blueprints/ember-cli-paint/index.js
+++ b/blueprints/ember-cli-paint/index.js
@@ -5,11 +5,7 @@ module.exports = {
 
   afterInstall: function() {
     return this.addPackagesToProject([
-      { name: 'liquid-fire', target: '0.17.1' },
-      { name: 'ember-rl-dropdown', target: 'git+https://git@github.com/alphasights/ember-rl-dropdown.git' },
-      { name: 'ember-cli-tooltipster', target: '0.0.6' },
-      { name: 'broccoli-sass', target: '0.4.0' },
-      { name: 'ember-scrollable', target: '0.1.0' }
+      { name: 'broccoli-sass', target: '0.6.6' }
     ]).then(function() {
       return this.addBowerPackagesToProject([
         { name: 'paint', target: '0.7.22' },

--- a/package.json
+++ b/package.json
@@ -27,11 +27,14 @@
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "1.3.0",
     "ember-cli-qunit": "0.3.9",
+    "ember-cli-tooltipster": "0.0.6",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.16.1",
     "ember-disable-prototype-extensions": "1.0.0",
     "ember-export-application-global": "1.0.2",
-    "ember-scrollable": "0.1.1"
+    "ember-rl-dropdown": "0.5.0",
+    "ember-scrollable": "0.1.1",
+    "liquid-fire": "0.20.4"
   },
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ember-cli-tooltipster": "0.0.6",
     "ember-rl-dropdown": "0.5.0",
     "ember-scrollable": "0.1.1",
-    "liquid-fire": "0.20.4"
+    "liquid-fire": "0.21.2"
   },
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -27,11 +27,13 @@
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "1.3.0",
     "ember-cli-qunit": "0.3.9",
-    "ember-cli-tooltipster": "0.0.6",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.16.1",
     "ember-disable-prototype-extensions": "1.0.0",
-    "ember-export-application-global": "1.0.2",
+    "ember-export-application-global": "1.0.2"
+  },
+  "dependencies": {
+    "ember-cli-tooltipster": "0.0.6",
     "ember-rl-dropdown": "0.5.0",
     "ember-scrollable": "0.1.1",
     "liquid-fire": "0.20.4"


### PR DESCRIPTION
- Remove blueprint files (let everyone create their own files)
- Move npm dependencies from blueprint to package.json
- Bump liquid-fire dependency that caused issues with ember-rl-dropdown.