### PR TITLE
Add structure for sub-navigation in sidebar

### DIFF
--- a/app/templates/components/as-sidebar.hbs
+++ b/app/templates/components/as-sidebar.hbs
@@ -25,7 +25,7 @@
             {{/if}}
           {{/link-to}}
         </li>
-      {{else}}
+      {{else if item.subNav}}
         <li class={{item.id}}>
           <ul>
             {{#each item.subNav as |subNavItem|}}

--- a/app/templates/components/as-sidebar.hbs
+++ b/app/templates/components/as-sidebar.hbs
@@ -14,16 +14,32 @@
 
   <ul>
     {{#each navigationItems as |item|}}
-      <li class={{item.id}}>
-        {{#link-to item.routeName}}
+      {{#if item.routeName}}
+        <li class={{item.id}}>
+          {{#link-to item.routeName}}
+            <i></i>
+            <span>{{item.name}}</span>
+
+            {{#if item.bubbleCount}}
+              <span class="bubble">{{item.bubbleCount}}</span>
+            {{/if}}
+          {{/link-to}}
+        </li>
+      {{else}}
+        <li class={{item.id}}>
           <i></i>
           <span>{{item.name}}</span>
-
-          {{#if item.bubbleCount}}
-            <span class="bubble">{{item.bubbleCount}}</span>
-          {{/if}}
-        {{/link-to}}
-      </li>
+          <ul>
+            {{#each item.subNav as |subNavItem|}}
+              <li class={{subNavItem.id}}>
+                <a href={{subNavItem.link}} target="_blank">
+                  <span>{{subNavItem.name}}</span>
+                </a>
+              </li>
+            {{/each}}
+          </ul>
+        </li>
+      {{/if}}
     {{/each}}
 
     {{yield}}

--- a/app/templates/components/as-sidebar.hbs
+++ b/app/templates/components/as-sidebar.hbs
@@ -27,8 +27,6 @@
         </li>
       {{else}}
         <li class={{item.id}}>
-          <i></i>
-          <span>{{item.name}}</span>
           <ul>
             {{#each item.subNav as |subNavItem|}}
               <li class={{subNavItem.id}}>


### PR DESCRIPTION
# What's Up

We're adding a sub-navigation section to Phoenix's sidebar to allow for a quick links section that can be opened or collapsed on click.  This PR implements the basic structure of the sub-nav in the sidebar. 

### Screen grab:
<img width="1274" alt="screenshot_8_25_15__6_19_pm" src="https://cloud.githubusercontent.com/assets/6817804/9481152/e3e63c44-4b55-11e5-993b-77406c805614.png">

###### See: https://github.com/alphasights/phoenix/pull/579 and https://github.com/alphasights/pistachio/pull/3106

