### PR TITLE
Use modernizr#2.3.8

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,8 @@
     "qunit": "1.17.1",
     "paint": "0.7.22",
     "spinjs": "2.0.1",
-    "trackpad-scroll-emulator": "^1.0.8"
+    "trackpad-scroll-emulator": "^1.0.8",
+    "modernizr": "https://github.com/components/modernizr.git#2.8.3"
   },
   "resolutions": {
     "jquery": "^1.11.1"

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
     this._super.included(app);
 
     app.import(path.join(app.bowerDirectory, 'paint/paint.scss'));
-    app.import(path.join(app.bowerDirectory, 'modernizr/src/Modernizr.js'));
+    app.import(path.join(app.bowerDirectory, 'modernizr/modernizr.js'));
     app.import(path.join(app.bowerDirectory, 'foundation/js/foundation/foundation.js'));
     app.import(path.join(app.bowerDirectory, 'foundation/js/foundation/foundation.dropdown.js'));
     app.import(path.join(app.bowerDirectory, 'foundation/js/foundation/foundation.tooltip.js'));


### PR DESCRIPTION
This forces us to use the `2.3.8` version instead of always getting the latest, that is what foundation is doing. Here's how the dependency tree looks like now:

```
├─┬ paint#0.7.22 (latest is 0.8.24)
│ ├── fontawesome#4.3.0 (latest is 4.4.0)
│ └─┬ foundation#5.5.2
│   ├── fastclick#1.0.6
│   ├── jquery#1.11.3 incompatible with >= 2.1.0 (3.0.0-alpha1+compat available)
│   ├─┬ jquery-placeholder#2.0.9 (latest is 2.1.2)
│   │ └── jquery#1.11.3 (3.0.0-alpha1+compat available)
│   ├─┬ jquery.cookie#1.4.1
│   │ └── jquery#1.11.3 (3.0.0-alpha1+compat available)
│   └── modernizr#2.8.3 (3.0.0 available)
```