### PR TITLE
Remove paint assets

### DIFF
--- a/app/templates/components/as-sidebar.hbs
+++ b/app/templates/components/as-sidebar.hbs
@@ -1,5 +1,5 @@
 <header>
-  <img src="assets/images/logo.png" alt={{applicationName}} />
+  <img src="/images/logo.png" alt={{applicationName}} />
   <h1>{{applicationName}}</h1>
 </header>
 

--- a/index.js
+++ b/index.js
@@ -34,13 +34,5 @@ module.exports = {
     app.import(path.join(app.bowerDirectory, 'fontawesome/fonts/fontawesome-webfont.eot'), {
       destDir: 'assets/fonts'
     });
-
-    app.import(path.join(app.bowerDirectory, 'paint/images/favicon.ico'), {
-      destDir: 'assets/images'
-    });
-
-    app.import(path.join(app.bowerDirectory, 'paint/images/logo.png'), {
-      destDir: 'assets/images'
-    });
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-paint",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "Foundation for Ember paint applications",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-paint",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Foundation for Ember paint applications",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Starting with `0.8.26`, paint doesn't hold image assets anymore. It's more convenient to leave apps to include their own logo / favicon, uploaded in the `/public/` folder.
