### PR TITLE
Add hooks for end/beginning of navigableModels

### DIFF
--- a/addon/mixins/models-navigation.js
+++ b/addon/mixins/models-navigation.js
@@ -1,71 +1,117 @@
 import Ember from 'ember';
 
-export default Ember.Mixin.create({
-  navigableModels: null,
-  modelRouteParams: [],
-  disableCycling: false,
-  navigableModel: Ember.computed.alias('model'),
+export var Navigator = Ember.Object.extend({
+  controller: null,
+
+  model: Ember.computed.oneWay('controller.navigableModel'),
+  models: Ember.computed.oneWay('controller.navigableModels'),
+  modelRouteParams: Ember.computed.oneWay('controller.modelRouteParams'),
+
   previousModel: null,
   nextModel: null,
 
-  isFirstModel: Ember.computed('navigableModel', 'navigableModels.[]', function() {
-    return Ember.isEqual(this.get('navigableModel'), this.get('navigableModels.firstObject'));
-  }),
-  isLastModel: Ember.computed('navigableModel', 'navigableModels.[]', function() {
-    return Ember.isEqual(this.get('navigableModel'), this.get('navigableModels.lastObject'));
-  }),
+  firstModel: Ember.computed.oneWay('models.firstObject'),
+  lastModel: Ember.computed.oneWay('models.lastObject'),
 
-  disablePrevious: Ember.computed.and('isFirstModel', 'disableCycling'),
-  disableNext: Ember.computed.and('isLastModel', 'disableCycling'),
-
-  updatePreviousAndNextModels: Ember.observer('navigableModel', function() {
-    Ember.run.scheduleOnce('afterRender', this, function() {
-      this.set('previousModel', this._getPreviousModel());
-      this.set('nextModel', this._getNextModel());
-    });
+  isFirstModel: Ember.computed('model', 'firstModel', function() {
+    return this.get('model') === this.get('firstModel');
   }),
 
-  _getPreviousModel: function() {
-    if (this.get('isFirstModel')) {
-      return this.get('navigableModels.lastObject');
-    } else {
+  isLastModel: Ember.computed('model', 'lastModel', function() {
+    return this.get('model') === this.get('lastModel');
+  }),
+
+  disablePrevious: Ember.computed.oneWay('isFirstModel'),
+  disableNext: Ember.computed.oneWay('isLastModel'),
+
+  updatePreviousAndNextModels: Ember.on('init', Ember.observer('model', 'models.[]', function() {
+    this.set('previousModel', this.getPreviousModel());
+    this.set('nextModel', this.getNextModel());
+  })),
+
+  getPreviousModel: function() {
+    if (!this.get('isFirstModel')) {
       return this._getModelAtOffset(-1);
     }
   },
 
-  _getNextModel: function() {
-    if (this.get('isLastModel')) {
-      return this.get('navigableModels.firstObject');
-    } else {
+  getNextModel: function() {
+    if (!this.get('isLastModel')) {
       return this._getModelAtOffset(1);
     }
   },
 
+  getPreviousModelBeforeFirst: function() {
+    return Ember.RSVP.resolve(this.get('firstModel'));
+  },
+
+  getNextModelAfterLast: function() {
+    return Ember.RSVP.resolve(this.get('lastModel'));
+  },
+
   _getModelAtOffset: function(offset) {
-    var index = this.get('navigableModels').indexOf(this.get('navigableModel'));
+    var models = this.get('models');
+    var index = models.indexOf(this.get('model'));
 
     if (index < 0) {
-      return this.get('navigableModels.firstObject');
+      return this.get('firstModel');
     } else {
-      return this.get('navigableModels').objectAt(index + offset);
+      return models.objectAt(index + offset);
+    }
+  },
+
+  previous: function() {
+    if (this.get('disablePrevious')) { return; }
+
+    let previousModel = this.get('previousModel');
+
+    if (this.get('isFirstModel')) {
+      this.getPreviousModelBeforeFirst().then((model) => {
+        this._navigateToModel(model);
+      });
+    } else if (previousModel) {
+      this._navigateToModel(previousModel);
+    }
+  },
+
+  next: function() {
+    if (this.get('disableNext')) { return; }
+
+    let nextModel = this.get('nextModel');
+
+    if (this.get('isLastModel')) {
+      this.getNextModelAfterLast().then((model) => {
+        this._navigateToModel(model);
+      });
+    } else if (nextModel) {
+      this._navigateToModel(nextModel);
     }
   },
 
   _navigateToModel: function(model) {
-    this.transitionToRoute(...this.get('modelRouteParams').concat(model.get('id')));
-  },
+    this.get('controller').transitionToRoute(...this.get('modelRouteParams').concat(model.get('id')));
+  }
+});
+
+export default Ember.Mixin.create({
+  navigableModel: Ember.computed.oneWay('model'),
+  navigableModels: null,
+  modelRouteParams: [],
+
+  navigator: Ember.computed(function() {
+    return Navigator.create({ controller: this });
+  }),
+
+  disablePrevious: Ember.computed.oneWay('navigator.disablePrevious'),
+  disableNext: Ember.computed.oneWay('navigator.disableNext'),
 
   actions: {
     previous: function() {
-      if (!this.get('disablePrevious')) {
-        this._navigateToModel(this.get('previousModel'));
-      }
+      this.get('navigator').previous();
     },
 
     next: function() {
-      if (!this.get('disableNext')) {
-        this._navigateToModel(this.get('nextModel'));
-      }
+      this.get('navigator').next();
     }
   }
 });


### PR DESCRIPTION
This change will make it easier to add custom behaviour for when we reach the beginning/end of the current list and click in the `previous` or `next` buttons.

In most cases, we'll want to go to the next or previous page and keep the navigation flowing, but it's up to the application using `ember-cli-paint` to decide what it should do.

Essentially, we are exposing two hooks to handle that, `getPreviousModelBeforeFirst` and `getNextModelAfterLast`, that are expected to return a promise that resolves the model that will be used as the next/previous record.

Here's an example implementation:

```javascript
import Ember from 'ember';
import ModelsNavigationMixin, { Navigator } from 'ember-cli-paint/mixins/models-navigation';

var CustomNavigator = Navigator.extend({
  controller: null,
  projectsController: null,

  model: Ember.computed.oneWay('controller.project'),
  models: Ember.computed.oneWay('projectsController.sortedProjects'),

  getNextModelAfterLast: function() {
    return this.get('projectsController').movePage(1).then((models) => {
      return models.get('firstObject');
    });
  },

  getPreviousModelBeforeFirst: function() {
    return this.get('projectsController').movePage(-1).then((model) => {
      return models.get('lastObject');
    });
  }
});

export default Ember.Controller.extend(ModelsNavigationMixin, {
  project: Ember.computed.oneWay('model.project'),
  projectsController: Ember.inject.controller('projects'),

  navigator: Ember.computed(function() {
    return CustomNavigator.create({
      controller: this,
      projectsController: this.get('projectsController')
    });
  })
}
```

We are also exposing `disablePrevious` and `disableNext` to the controller. By default these functions will just check if the current model is the first/last, but we can have custom behaviours per app.