### PR TITLE
stop panel closing when selecting options

### DIFF
--- a/addon/components/as-side-panel.js
+++ b/addon/components/as-side-panel.js
@@ -19,6 +19,10 @@ export default Ember.Component.extend(KeyEventsMixin, TransitionDurationMixin, I
       var $target = Ember.$(event.target);
       var $nonBlurringElements = this.$('> div');
 
+      if ($target.closest('html').length === 0) {
+        return;
+      }
+
       if($target.closest($nonBlurringElements).length === 0) {
         this.send('close');
       }


### PR DESCRIPTION
When clicking on an element that is no longer in the DOM the test fails. Here we check if the element still exists and if it does, just return.