### PR TITLE
Don't update links to previous and next models when collection changes

### DIFF
--- a/addon/mixins/models-navigation.js
+++ b/addon/mixins/models-navigation.js
@@ -24,7 +24,7 @@ export var Navigator = Ember.Object.extend({
   disablePrevious: Ember.computed.oneWay('isFirstModel'),
   disableNext: Ember.computed.oneWay('isLastModel'),
 
-  updatePreviousAndNextModels: Ember.on('init', Ember.observer('model', 'models.[]', function() {
+  updatePreviousAndNextModels: Ember.on('init', Ember.observer('model', function() {
     this.set('previousModel', this.getPreviousModel());
     this.set('nextModel', this.getNextModel());
   })),


### PR DESCRIPTION
When we did the refactoring of the model navigation, we have added this back in :(

This is the use case:

- model in a collection
- change the model, so that it's removed from the collection
- previous and next model are being recalculated because the collection changes
- unhappy me

Also, we should extract this mixin into a separate component and test it properly.