### PR TITLE
Navigate to last model when we update the navigable models collection

### DIFF
--- a/addon/mixins/models-navigation.js
+++ b/addon/mixins/models-navigation.js
@@ -63,7 +63,7 @@ export var Navigator = Ember.Object.extend({
   previous: function() {
     if (this.get('disablePrevious')) { return; }
 
-    let previousModel = this.get('previousModel');
+    let previousModel = this.get('previousModel') || this.get('firstModel');
 
     if (this.get('isFirstModel')) {
       this.getPreviousModelBeforeFirst().then((model) => {
@@ -77,7 +77,7 @@ export var Navigator = Ember.Object.extend({
   next: function() {
     if (this.get('disableNext')) { return; }
 
-    let nextModel = this.get('nextModel');
+    let nextModel = this.get('nextModel') || this.get('lastModel');
 
     if (this.get('isLastModel')) {
       this.getNextModelAfterLast().then((model) => {


### PR DESCRIPTION
How to reproduce the problem:

* We are on the last model of the collection
* A new element is added to the end of the collection
* We try to go to the next model
* Nothing happens.

Instead, if this situation happens, we can simply navigate to the last element of the collection. (Same logic applies for the first model and going backwards)