### PR TITLE
Add class to body when side panel is active

### DIFF
--- a/addon/components/as-side-panel.js
+++ b/addon/components/as-side-panel.js
@@ -11,6 +11,7 @@ export default Ember.Component.extend(KeyEventsMixin, TransitionDurationMixin, I
   onDidInsertElement: function() {
     Ember.run.schedule('afterRender', () => {
       this.set('isActive', true);
+      Ember.$('body').addClass('body-overlay-active');
     });
 
     // TODO: Figure out why using the Ember `click` instance method resulted in
@@ -35,6 +36,7 @@ export default Ember.Component.extend(KeyEventsMixin, TransitionDurationMixin, I
 
       Ember.run.later(this, function() {
         this.sendAction('close');
+        Ember.$('body').removeClass('body-overlay-active');
       }, this.get('transitionDuration'));
     },
 


### PR DESCRIPTION
This PR toggles a class on the `body` to enable / disable background scrolling when the side-panel is inactive / active.