### PR TITLE
remove overlay body in destroy hook

### DIFF
--- a/addon/components/as-side-panel.js
+++ b/addon/components/as-side-panel.js
@@ -30,13 +30,17 @@ export default Ember.Component.extend(KeyEventsMixin, TransitionDurationMixin, I
     });
   }.on('didInsertElement'),
 
+  willDestroyElement() {
+    this._super(...arguments);
+    Ember.$('body').removeClass('body-overlay-active');
+  },
+
   actions: {
     close: function() {
       this.set('isActive', false);
 
       Ember.run.later(this, function() {
         this.sendAction('close');
-        Ember.$('body').removeClass('body-overlay-active');
       }, this.get('transitionDuration'));
     },
 


### PR DESCRIPTION
When not using the close action defined in the side-panel component, the overlay body class is not removed and the page remains un-scrollable.

Moving it to the didDestroy will mean that the class is always removed.